### PR TITLE
Fix image paths and add tour carousel

### DIFF
--- a/bormio.html
+++ b/bormio.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bormio e Passo Stelvio | Giro Pizza</title>
+  <link rel="stylesheet" href="fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contatti.html" class="nav-button">CONTATTI</a>
+    <a href="chi-siamo.html" class="nav-button">CHI SIAMO</a>
+  </nav>
+  <div class="language-selector">
+    <a href="bormio.html" class="lang-button active">IT</a>
+    <a href="en/bormio.html" class="lang-button">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" id="hero">
+      <div class="background" style="background-image: url('images/carousel/carousel_1.jpg')"></div>
+      <div class="content">
+        <h1 class="fade-in">BORMIO E STELVIO</h1>
+        <p class="quote fade-in delay-1">Scalate leggendarie e panorami alpini</p>
+      </div>
+      <div class="scroll-indicator"></div>
+    </section>
+    <section class="fullpage-section" id="tour-details">
+      <div class="background gradient"></div>
+      <div class="content">
+        <h2 class="fade-in">IL TOUR</h2>
+        <div class="stats">
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="80">0</span> km</div>
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="2200">0</span> m</div>
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="5">0</span> h</div>
+        </div>
+        <p class="description fade-in delay-2">Tre giorni alla scoperta di Bormio con salita al leggendario Stelvio. Pernotti in hotel tipico e degustazioni locali.</p>
+        <p class="description fade-in delay-2">Prezzo: 350€</p>
+        <a href="contatti.html" class="minimal-button fade-in delay-3">PRENOTA</a>
+      </div>
+    </section>
+  </div>
+<script src="main.js"></script>
+</body>
+</html>

--- a/dolomiti.html
+++ b/dolomiti.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dolomiti: Sella Ronda e Giau | Giro Pizza</title>
+  <link rel="stylesheet" href="fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contatti.html" class="nav-button">CONTATTI</a>
+    <a href="chi-siamo.html" class="nav-button">CHI SIAMO</a>
+  </nav>
+  <div class="language-selector">
+    <a href="dolomiti.html" class="lang-button active">IT</a>
+    <a href="en/dolomiti.html" class="lang-button">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" id="hero">
+      <div class="background" style="background-image: url('images/carousel/carousel_2.jpg')"></div>
+      <div class="content">
+        <h1 class="fade-in">DOLOMITI</h1>
+        <p class="quote fade-in delay-1">Sella Ronda e Giau in un'unica avventura</p>
+      </div>
+      <div class="scroll-indicator"></div>
+    </section>
+    <section class="fullpage-section" id="tour-details">
+      <div class="background gradient"></div>
+      <div class="content">
+        <h2 class="fade-in">IL TOUR</h2>
+        <div class="stats">
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="60">0</span> km</div>
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="1800">0</span> m</div>
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="4">0</span> h</div>
+        </div>
+        <p class="description fade-in delay-2">Cinque giorni immersi nei passi più iconici delle Dolomiti con assistenza e ristori selezionati.</p>
+        <p class="description fade-in delay-2">Prezzo: 450€</p>
+        <a href="contatti.html" class="minimal-button fade-in delay-3">PRENOTA</a>
+      </div>
+    </section>
+  </div>
+<script src="main.js"></script>
+</body>
+</html>

--- a/en/bormio.html
+++ b/en/bormio.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bormio and Stelvio Pass | Giro Pizza</title>
+  <link rel="stylesheet" href="../fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contact.html" class="nav-button">CONTACT</a>
+    <a href="about-us.html" class="nav-button">ABOUT</a>
+  </nav>
+  <div class="language-selector">
+    <a href="../bormio.html" class="lang-button">IT</a>
+    <a href="bormio.html" class="lang-button active">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" id="hero">
+      <div class="background" style="background-image: url('../images/carousel/carousel_1.jpg')"></div>
+      <div class="content">
+        <h1 class="fade-in">BORMIO & STELVIO</h1>
+        <p class="quote fade-in delay-1">Legendary climbs and alpine views</p>
+      </div>
+      <div class="scroll-indicator"></div>
+    </section>
+    <section class="fullpage-section" id="tour-details">
+      <div class="background gradient"></div>
+      <div class="content">
+        <h2 class="fade-in">THE TOUR</h2>
+        <div class="stats">
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="80">0</span> km</div>
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="2200">0</span> m</div>
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="5">0</span> h</div>
+        </div>
+        <p class="description fade-in delay-2">Three days exploring Bormio with the famous Stelvio climb. Overnight in a local hotel with tastings.</p>
+        <p class="description fade-in delay-2">Price: €350</p>
+        <a href="contact.html" class="minimal-button fade-in delay-3">BOOK</a>
+      </div>
+    </section>
+  </div>
+<script src="../main.js"></script>
+</body>
+</html>

--- a/en/dolomiti.html
+++ b/en/dolomiti.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dolomites: Sella Ronda and Giau | Giro Pizza</title>
+  <link rel="stylesheet" href="../fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contact.html" class="nav-button">CONTACT</a>
+    <a href="about-us.html" class="nav-button">ABOUT</a>
+  </nav>
+  <div class="language-selector">
+    <a href="../dolomiti.html" class="lang-button">IT</a>
+    <a href="dolomiti.html" class="lang-button active">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" id="hero">
+      <div class="background" style="background-image: url('../images/carousel/carousel_2.jpg')"></div>
+      <div class="content">
+        <h1 class="fade-in">DOLOMITES</h1>
+        <p class="quote fade-in delay-1">Sella Ronda and Giau in one adventure</p>
+      </div>
+      <div class="scroll-indicator"></div>
+    </section>
+    <section class="fullpage-section" id="tour-details">
+      <div class="background gradient"></div>
+      <div class="content">
+        <h2 class="fade-in">THE TOUR</h2>
+        <div class="stats">
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="60">0</span> km</div>
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="1800">0</span> m</div>
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="4">0</span> h</div>
+        </div>
+        <p class="description fade-in delay-2">Five days riding the most iconic Dolomite passes with support and curated food stops.</p>
+        <p class="description fade-in delay-2">Price: €450</p>
+        <a href="contact.html" class="minimal-button fade-in delay-3">BOOK</a>
+      </div>
+    </section>
+  </div>
+<script src="../main.js"></script>
+</body>
+</html>

--- a/en/index.html
+++ b/en/index.html
@@ -30,7 +30,7 @@
   
   <div class="fullpage-container">
     <section class="fullpage-section" id="hero">
-      <div class="background" style="background-image: url('https://images.unsplash.com/photo-1501621667575-af81f1f0bacc?ixlib=rb-4.0.3&auto=format&fit=crop&w=1950&q=80')"></div>
+      <div class="background" style="background-image: url('../images/home.jpg')"></div>
       <div class="content">
         <h1 class="fade-in">GIRO PIZZA</h1>
         <p class="quote fade-in delay-1">An endless loop of pizza slices and hidden climbs</p>
@@ -39,22 +39,47 @@
     </section>
     
     <section class="fullpage-section" id="tour-bergamo">
-      <div class="background" style="background-image: url('https://images.unsplash.com/photo-1506535995048-638aa1b62b77?ixlib=rb-4.0.3&auto=format&fit=crop&w=1950&q=80')"></div>
+      <div class="background gradient"></div>
       <div class="content">
         <h2 class="fade-in">HILLS TOUR</h2>
-        <div class="stats">
-          <div class="stat fade-in delay-1">
-            <span class="stat-number" data-value="45">0</span> km
+        <div class="carousel tour-carousel">
+          <div class="carousel-item active" style="background-image: url('../images/carousel/carousel_1.jpg')">
+            <h3>Bormio & Stelvio</h3>
+            <div class="stats">
+              <div class="stat fade-in delay-1"><span class="stat-number" data-value="80">0</span> km</div>
+              <div class="stat fade-in delay-1"><span class="stat-number" data-value="2200">0</span> m</div>
+              <div class="stat fade-in delay-1"><span class="stat-number" data-value="5">0</span> h</div>
+            </div>
+            <a href="bormio.html" class="minimal-button fade-in delay-2">DETAILS</a>
           </div>
-          <div class="stat fade-in delay-1">
-            <span class="stat-number" data-value="850">0</span> m
+          <div class="carousel-item" style="background-image: url('../images/carousel/carousel_2.jpg')">
+            <h3>Dolomites</h3>
+            <div class="stats">
+              <div class="stat"><span class="stat-number" data-value="60">0</span> km</div>
+              <div class="stat"><span class="stat-number" data-value="1800">0</span> m</div>
+              <div class="stat"><span class="stat-number" data-value="4">0</span> h</div>
+            </div>
+            <a href="dolomiti.html" class="minimal-button">DETAILS</a>
           </div>
-          <div class="stat fade-in delay-1">
-            <span class="stat-number" data-value="3.5">0</span> h
+          <div class="carousel-item" style="background-image: url('../images/home.jpg')">
+            <h3>Valpolicella</h3>
+            <div class="stats">
+              <div class="stat"><span class="stat-number" data-value="70">0</span> km</div>
+              <div class="stat"><span class="stat-number" data-value="1000">0</span> m</div>
+              <div class="stat"><span class="stat-number" data-value="4">0</span> h</div>
+            </div>
+            <a href="valpolicella.html" class="minimal-button">DETAILS</a>
           </div>
         </div>
-        <p class="description fade-in delay-2">A breathtaking route through the Bergamo hills, discovering hidden roads and unforgettable landscapes. You'll ride through medieval villages, vineyards and olive groves with selected food stops.</p>
-        <a href="#" class="minimal-button fade-in delay-3">DISCOVER</a>
+        <div class="carousel-indicators">
+          <span class="indicator active"></span>
+          <span class="indicator"></span>
+          <span class="indicator"></span>
+        </div>
+        <div class="carousel-controls">
+          <button class="carousel-control prev">&lt;</button>
+          <button class="carousel-control next">&gt;</button>
+        </div>
       </div>
     </section>
     
@@ -112,8 +137,8 @@
 
     <section class="fullpage-section" id="gallery">
       <div class="carousel">
-        <div class="carousel-item active" style="background-image: url('../images/carousel/PXL_20250528_044329734.jpg')"></div>
-        <div class="carousel-item" style="background-image: url('../images/carousel/PXL_20250601_064127602.jpg')"></div>
+        <div class="carousel-item active" style="background-image: url('../images/carousel/carousel_1.jpg')"></div>
+        <div class="carousel-item" style="background-image: url('../images/carousel/carousel_2.jpg')"></div>
       </div>
       <div class="carousel-indicators">
         <span class="indicator active"></span>
@@ -173,54 +198,49 @@
         observer.observe(section);
       });
       
-      // Carousel handling
-      const carouselItems = document.querySelectorAll('.carousel-item');
-      const indicators = document.querySelectorAll('.indicator');
-      const prevBtn = document.querySelector('.prev');
-      const nextBtn = document.querySelector('.next');
-      let currentSlide = 0;
-      
-      function showSlide(index) {
-        // Rimuovi la classe active da tutti gli elementi
-        carouselItems.forEach(item => item.classList.remove('active'));
-        indicators.forEach(indicator => indicator.classList.remove('active'));
-        
-        // Aggiungi la classe active all'elemento corrente
-        carouselItems[index].classList.add('active');
-        indicators[index].classList.add('active');
-        currentSlide = index;
-      }
-      
-      // Event listeners per i controlli del carosello
-      if (prevBtn) {
-        prevBtn.addEventListener('click', () => {
-          let index = currentSlide - 1;
-          if (index < 0) index = carouselItems.length - 1;
-          showSlide(index);
+      // Handle all carousels on the page
+      document.querySelectorAll('.carousel').forEach(carousel => {
+        const items = carousel.querySelectorAll('.carousel-item');
+        const parent = carousel.parentElement;
+        const indicators = parent.querySelectorAll('.indicator');
+        const prevBtn = parent.querySelector('.prev');
+        const nextBtn = parent.querySelector('.next');
+        let current = 0;
+
+        function showSlide(index) {
+          items.forEach(i => i.classList.remove('active'));
+          indicators.forEach(ind => ind.classList.remove('active'));
+          items[index].classList.add('active');
+          indicators[index].classList.add('active');
+          current = index;
+        }
+
+        if (prevBtn) {
+          prevBtn.addEventListener('click', () => {
+            let idx = current - 1;
+            if (idx < 0) idx = items.length - 1;
+            showSlide(idx);
+          });
+        }
+
+        if (nextBtn) {
+          nextBtn.addEventListener('click', () => {
+            let idx = current + 1;
+            if (idx >= items.length) idx = 0;
+            showSlide(idx);
+          });
+        }
+
+        indicators.forEach((indicator, idx) => {
+          indicator.addEventListener('click', () => showSlide(idx));
         });
-      }
-      
-      if (nextBtn) {
-        nextBtn.addEventListener('click', () => {
-          let index = currentSlide + 1;
-          if (index >= carouselItems.length) index = 0;
-          showSlide(index);
-        });
-      }
-      
-      // Event listeners per gli indicatori
-      indicators.forEach((indicator, index) => {
-        indicator.addEventListener('click', () => {
-          showSlide(index);
-        });
+
+        setInterval(() => {
+          let idx = current + 1;
+          if (idx >= items.length) idx = 0;
+          showSlide(idx);
+        }, 5000);
       });
-      
-      // Rotazione automatica del carosello
-      setInterval(() => {
-        let index = currentSlide + 1;
-        if (index >= carouselItems.length) index = 0;
-        showSlide(index);
-      }, 5000);
     });
   </script>
 </body>

--- a/en/valpolicella.html
+++ b/en/valpolicella.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Valpolicella and Lessinia | Giro Pizza</title>
+  <link rel="stylesheet" href="../fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contact.html" class="nav-button">CONTACT</a>
+    <a href="about-us.html" class="nav-button">ABOUT</a>
+  </nav>
+  <div class="language-selector">
+    <a href="../valpolicella.html" class="lang-button">IT</a>
+    <a href="valpolicella.html" class="lang-button active">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" id="hero">
+      <div class="background" style="background-image: url('../images/home.jpg')"></div>
+      <div class="content">
+        <h1 class="fade-in">VALPOLICELLA</h1>
+        <p class="quote fade-in delay-1">Vineyards, Lessinia and rich flavours</p>
+      </div>
+      <div class="scroll-indicator"></div>
+    </section>
+    <section class="fullpage-section" id="tour-details">
+      <div class="background gradient"></div>
+      <div class="content">
+        <h2 class="fade-in">THE TOUR</h2>
+        <div class="stats">
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="70">0</span> km</div>
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="1000">0</span> m</div>
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="4">0</span> h</div>
+        </div>
+        <p class="description fade-in delay-2">Three days riding through Valpolicella vineyards and the climbs of Lessinia with Amarone tastings.</p>
+        <p class="description fade-in delay-2">Price: €300</p>
+        <a href="contact.html" class="minimal-button fade-in delay-3">BOOK</a>
+      </div>
+    </section>
+  </div>
+<script src="../main.js"></script>
+</body>
+</html>

--- a/fixed-styles.css
+++ b/fixed-styles.css
@@ -62,6 +62,11 @@ html, body {
   background: linear-gradient(135deg, #1A3C2B 0%, #4A7C59 100%);
 }
 
+/* Maggiore oscuramento per l'immagine della home */
+#hero .background::after {
+  background: rgba(0, 0, 0, 0.45);
+}
+
 /* Stili Contenuto */
 .content {
   width: 100%;

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
   
   <div class="fullpage-container">
     <section class="fullpage-section" id="hero">
-      <div class="background" style="background-image: url('https://images.unsplash.com/photo-1501621667575-af81f1f0bacc?ixlib=rb-4.0.3&auto=format&fit=crop&w=1950&q=80')"></div>
+      <div class="background" style="background-image: url('images/home.jpg')"></div>
       <div class="content">
         <h1 class="fade-in">GIRO PIZZA</h1>
         <p class="quote fade-in delay-1">Un'infinita giostra di fette di pizza e salite nascoste</p>
@@ -39,22 +39,47 @@
     </section>
     
     <section class="fullpage-section" id="tour-bergamo">
-      <div class="background" style="background-image: url('https://images.unsplash.com/photo-1506535995048-638aa1b62b77?ixlib=rb-4.0.3&auto=format&fit=crop&w=1950&q=80')"></div>
+      <div class="background gradient"></div>
       <div class="content">
         <h2 class="fade-in">TOUR DELLE COLLINE</h2>
-        <div class="stats">
-          <div class="stat fade-in delay-1">
-            <span class="stat-number" data-value="45">0</span> km
+        <div class="carousel tour-carousel">
+          <div class="carousel-item active" style="background-image: url('images/carousel/carousel_1.jpg')">
+            <h3>Bormio e Stelvio</h3>
+            <div class="stats">
+              <div class="stat fade-in delay-1"><span class="stat-number" data-value="80">0</span> km</div>
+              <div class="stat fade-in delay-1"><span class="stat-number" data-value="2200">0</span> m</div>
+              <div class="stat fade-in delay-1"><span class="stat-number" data-value="5">0</span> h</div>
+            </div>
+            <a href="bormio.html" class="minimal-button fade-in delay-2">DETTAGLI</a>
           </div>
-          <div class="stat fade-in delay-1">
-            <span class="stat-number" data-value="850">0</span> m
+          <div class="carousel-item" style="background-image: url('images/carousel/carousel_2.jpg')">
+            <h3>Dolomiti</h3>
+            <div class="stats">
+              <div class="stat"><span class="stat-number" data-value="60">0</span> km</div>
+              <div class="stat"><span class="stat-number" data-value="1800">0</span> m</div>
+              <div class="stat"><span class="stat-number" data-value="4">0</span> h</div>
+            </div>
+            <a href="dolomiti.html" class="minimal-button">DETTAGLI</a>
           </div>
-          <div class="stat fade-in delay-1">
-            <span class="stat-number" data-value="3.5">0</span> ore
+          <div class="carousel-item" style="background-image: url('images/home.jpg')">
+            <h3>Valpolicella</h3>
+            <div class="stats">
+              <div class="stat"><span class="stat-number" data-value="70">0</span> km</div>
+              <div class="stat"><span class="stat-number" data-value="1000">0</span> m</div>
+              <div class="stat"><span class="stat-number" data-value="4">0</span> h</div>
+            </div>
+            <a href="valpolicella.html" class="minimal-button">DETTAGLI</a>
           </div>
         </div>
-        <p class="description fade-in delay-2">Un percorso mozzafiato tra le colline bergamasche, alla scoperta di strade poco conosciute e panorami indimenticabili. Attraverserai borghi medievali, vigneti e uliveti, con soste gastronomiche selezionate.</p>
-        <a href="#" class="minimal-button fade-in delay-3">SCOPRI</a>
+        <div class="carousel-indicators">
+          <span class="indicator active"></span>
+          <span class="indicator"></span>
+          <span class="indicator"></span>
+        </div>
+        <div class="carousel-controls">
+          <button class="carousel-control prev">&lt;</button>
+          <button class="carousel-control next">&gt;</button>
+        </div>
       </div>
     </section>
     
@@ -112,8 +137,8 @@
 
     <section class="fullpage-section" id="gallery">
       <div class="carousel">
-        <div class="carousel-item active" style="background-image: url('images/carousel/PXL_20250528_044329734.jpg')"></div>
-        <div class="carousel-item" style="background-image: url('images/carousel/PXL_20250601_064127602.jpg')"></div>
+        <div class="carousel-item active" style="background-image: url('images/carousel/carousel_1.jpg')"></div>
+        <div class="carousel-item" style="background-image: url('images/carousel/carousel_2.jpg')"></div>
       </div>
       <div class="carousel-indicators">
         <span class="indicator active"></span>
@@ -173,54 +198,49 @@
         observer.observe(section);
       });
       
-      // Gestione del carosello
-      const carouselItems = document.querySelectorAll('.carousel-item');
-      const indicators = document.querySelectorAll('.indicator');
-      const prevBtn = document.querySelector('.prev');
-      const nextBtn = document.querySelector('.next');
-      let currentSlide = 0;
-      
-      function showSlide(index) {
-        // Rimuovi la classe active da tutti gli elementi
-        carouselItems.forEach(item => item.classList.remove('active'));
-        indicators.forEach(indicator => indicator.classList.remove('active'));
-        
-        // Aggiungi la classe active all'elemento corrente
-        carouselItems[index].classList.add('active');
-        indicators[index].classList.add('active');
-        currentSlide = index;
-      }
-      
-      // Event listeners per i controlli del carosello
-      if (prevBtn) {
-        prevBtn.addEventListener('click', () => {
-          let index = currentSlide - 1;
-          if (index < 0) index = carouselItems.length - 1;
-          showSlide(index);
+      // Gestione di tutti i carousel presenti nella pagina
+      document.querySelectorAll('.carousel').forEach(carousel => {
+        const items = carousel.querySelectorAll('.carousel-item');
+        const parent = carousel.parentElement;
+        const indicators = parent.querySelectorAll('.indicator');
+        const prevBtn = parent.querySelector('.prev');
+        const nextBtn = parent.querySelector('.next');
+        let current = 0;
+
+        function showSlide(index) {
+          items.forEach(i => i.classList.remove('active'));
+          indicators.forEach(ind => ind.classList.remove('active'));
+          items[index].classList.add('active');
+          indicators[index].classList.add('active');
+          current = index;
+        }
+
+        if (prevBtn) {
+          prevBtn.addEventListener('click', () => {
+            let idx = current - 1;
+            if (idx < 0) idx = items.length - 1;
+            showSlide(idx);
+          });
+        }
+
+        if (nextBtn) {
+          nextBtn.addEventListener('click', () => {
+            let idx = current + 1;
+            if (idx >= items.length) idx = 0;
+            showSlide(idx);
+          });
+        }
+
+        indicators.forEach((indicator, idx) => {
+          indicator.addEventListener('click', () => showSlide(idx));
         });
-      }
-      
-      if (nextBtn) {
-        nextBtn.addEventListener('click', () => {
-          let index = currentSlide + 1;
-          if (index >= carouselItems.length) index = 0;
-          showSlide(index);
-        });
-      }
-      
-      // Event listeners per gli indicatori
-      indicators.forEach((indicator, index) => {
-        indicator.addEventListener('click', () => {
-          showSlide(index);
-        });
+
+        setInterval(() => {
+          let idx = current + 1;
+          if (idx >= items.length) idx = 0;
+          showSlide(idx);
+        }, 5000);
       });
-      
-      // Rotazione automatica del carosello
-      setInterval(() => {
-        let index = currentSlide + 1;
-        if (index >= carouselItems.length) index = 0;
-        showSlide(index);
-      }, 5000);
     });
   </script>
 </body>

--- a/valpolicella.html
+++ b/valpolicella.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Valpolicella e Lessinia | Giro Pizza</title>
+  <link rel="stylesheet" href="fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contatti.html" class="nav-button">CONTATTI</a>
+    <a href="chi-siamo.html" class="nav-button">CHI SIAMO</a>
+  </nav>
+  <div class="language-selector">
+    <a href="valpolicella.html" class="lang-button active">IT</a>
+    <a href="en/valpolicella.html" class="lang-button">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" id="hero">
+      <div class="background" style="background-image: url('images/home.jpg')"></div>
+      <div class="content">
+        <h1 class="fade-in">VALPOLICELLA</h1>
+        <p class="quote fade-in delay-1">Vigneti, Lessinia e sapori intensi</p>
+      </div>
+      <div class="scroll-indicator"></div>
+    </section>
+    <section class="fullpage-section" id="tour-details">
+      <div class="background gradient"></div>
+      <div class="content">
+        <h2 class="fade-in">IL TOUR</h2>
+        <div class="stats">
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="70">0</span> km</div>
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="1000">0</span> m</div>
+          <div class="stat fade-in delay-1"><span class="stat-number" data-value="4">0</span> h</div>
+        </div>
+        <p class="description fade-in delay-2">Tre giorni tra i vigneti della Valpolicella e le salite della Lessinia con degustazioni di Amarone.</p>
+        <p class="description fade-in delay-2">Prezzo: 300€</p>
+        <a href="contatti.html" class="minimal-button fade-in delay-3">PRENOTA</a>
+      </div>
+    </section>
+  </div>
+<script src="main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- use local home image for hero
- build carousel for Tour delle Colline with links to new pages
- load gallery images from repo
- tweak hero overlay style
- add tour detail pages in Italian and English
- update carousel script to support multiple instances

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fff9a0c208320bb66bc07a615836c