### PR TITLE
UI tweaks and detailed Dolomiti info

### DIFF
--- a/dolomiti.html
+++ b/dolomiti.html
@@ -9,6 +9,7 @@
 <body>
   <nav class="minimal-nav">
     <a href="index.html" class="nav-button">HOME</a>
+    <a href="tour.html" class="nav-button">TOUR</a>
     <a href="contatti.html" class="nav-button">CONTATTI</a>
     <a href="chi-siamo.html" class="nav-button">CHI SIAMO</a>
   </nav>
@@ -37,6 +38,45 @@
         <p class="description fade-in delay-2">Cinque giorni immersi nei passi più iconici delle Dolomiti con assistenza e ristori selezionati.</p>
         <p class="description fade-in delay-2">Prezzo: 450€</p>
         <a href="contatti.html" class="minimal-button fade-in delay-3">PRENOTA</a>
+      </div>
+    </section>
+
+    <section class="fullpage-section">
+      <div class="background gradient"></div>
+      <div class="content">
+        <h2 class="fade-in">Tappa 1 - Sella Ronda</h2>
+        <div class="stats">
+          <div class="stat"><span class="stat-number" data-value="55">0</span> km</div>
+          <div class="stat"><span class="stat-number" data-value="1700">0</span> m</div>
+          <div class="stat"><span class="stat-number" data-value="3">0</span> h</div>
+        </div>
+        <p class="description fade-in delay-2">Giro completo dei quattro passi attorno al massiccio del Sella.</p>
+      </div>
+    </section>
+
+    <section class="fullpage-section">
+      <div class="background gradient"></div>
+      <div class="content">
+        <h2 class="fade-in">Tappa 2 - Passo Giau</h2>
+        <div class="stats">
+          <div class="stat"><span class="stat-number" data-value="30">0</span> km</div>
+          <div class="stat"><span class="stat-number" data-value="1300">0</span> m</div>
+          <div class="stat"><span class="stat-number" data-value="2">0</span> h</div>
+        </div>
+        <p class="description fade-in delay-2">L'ascesa al Giau con panorami indimenticabili sulle Tofane.</p>
+      </div>
+    </section>
+
+    <section class="fullpage-section">
+      <div class="background gradient"></div>
+      <div class="content">
+        <h2 class="fade-in">Tappa 3 - Marmolada</h2>
+        <div class="stats">
+          <div class="stat"><span class="stat-number" data-value="45">0</span> km</div>
+          <div class="stat"><span class="stat-number" data-value="1600">0</span> m</div>
+          <div class="stat"><span class="stat-number" data-value="3">0</span> h</div>
+        </div>
+        <p class="description fade-in delay-2">Fedaia e viste sulla regina delle Dolomiti per concludere il viaggio.</p>
       </div>
     </section>
   </div>

--- a/en/dolomiti.html
+++ b/en/dolomiti.html
@@ -9,6 +9,7 @@
 <body>
   <nav class="minimal-nav">
     <a href="index.html" class="nav-button">HOME</a>
+    <a href="../tour.html" class="nav-button">TOURS</a>
     <a href="contact.html" class="nav-button">CONTACT</a>
     <a href="about-us.html" class="nav-button">ABOUT</a>
   </nav>
@@ -37,6 +38,45 @@
         <p class="description fade-in delay-2">Five days riding the most iconic Dolomite passes with support and curated food stops.</p>
         <p class="description fade-in delay-2">Price: €450</p>
         <a href="contact.html" class="minimal-button fade-in delay-3">BOOK</a>
+      </div>
+    </section>
+
+    <section class="fullpage-section">
+      <div class="background gradient"></div>
+      <div class="content">
+        <h2 class="fade-in">Stage 1 - Sella Ronda</h2>
+        <div class="stats">
+          <div class="stat"><span class="stat-number" data-value="55">0</span> km</div>
+          <div class="stat"><span class="stat-number" data-value="1700">0</span> m</div>
+          <div class="stat"><span class="stat-number" data-value="3">0</span> h</div>
+        </div>
+        <p class="description fade-in delay-2">Complete loop around the Sella group across four legendary passes.</p>
+      </div>
+    </section>
+
+    <section class="fullpage-section">
+      <div class="background gradient"></div>
+      <div class="content">
+        <h2 class="fade-in">Stage 2 - Passo Giau</h2>
+        <div class="stats">
+          <div class="stat"><span class="stat-number" data-value="30">0</span> km</div>
+          <div class="stat"><span class="stat-number" data-value="1300">0</span> m</div>
+          <div class="stat"><span class="stat-number" data-value="2">0</span> h</div>
+        </div>
+        <p class="description fade-in delay-2">The climb to Giau offers unforgettable views over the Tofane massif.</p>
+      </div>
+    </section>
+
+    <section class="fullpage-section">
+      <div class="background gradient"></div>
+      <div class="content">
+        <h2 class="fade-in">Stage 3 - Marmolada</h2>
+        <div class="stats">
+          <div class="stat"><span class="stat-number" data-value="45">0</span> km</div>
+          <div class="stat"><span class="stat-number" data-value="1600">0</span> m</div>
+          <div class="stat"><span class="stat-number" data-value="3">0</span> h</div>
+        </div>
+        <p class="description fade-in delay-2">Fedaia pass and views of the "Queen of the Dolomites" close the adventure.</p>
       </div>
     </section>
   </div>

--- a/en/index.html
+++ b/en/index.html
@@ -30,7 +30,7 @@
   
   <div class="fullpage-container">
     <section class="fullpage-section" id="hero">
-      <div class="background" style="background-image: url('../images/home.jpg')"></div>
+      <div class="background" style="background-image: url('../images/home.png')"></div>
       <div class="content">
         <h1 class="fade-in">GIRO PIZZA</h1>
         <p class="quote fade-in delay-1">An endless loop of pizza slices and hidden climbs</p>
@@ -41,7 +41,7 @@
     <section class="fullpage-section" id="tour-bergamo">
       <div class="background gradient"></div>
       <div class="content">
-        <h2 class="fade-in">HILLS TOUR</h2>
+        <h2 class="fade-in">OUR TOURS</h2>
         <div class="carousel tour-carousel">
           <div class="carousel-item active" style="background-image: url('../images/carousel/carousel_1.jpg')">
           <h3>Bormio & Stelvio</h3>
@@ -63,7 +63,7 @@
             </div>
             <a href="dolomiti.html" class="minimal-button">DETAILS</a>
           </div>
-          <div class="carousel-item" style="background-image: url('../images/home.jpg')">
+          <div class="carousel-item" style="background-image: url('../images/home.png')">
           <h3>Valpolicella</h3>
           <p class="carousel-description">Vineyards, gentle climbs and great wines.</p>
           <div class="stats">
@@ -123,14 +123,6 @@
       </div>
     </section>
 
-    <section class="fullpage-section" id="featured-tours">
-      <div class="background" style="background-image: url('https://images.unsplash.com/photo-1500375592092-40eb2168fd21?ixlib=rb-4.0.3&auto=format&fit=crop&w=1950&q=80')"></div>
-      <div class="content">
-        <h2 class="fade-in">FEATURED TOURS</h2>
-        <p class="fade-in delay-1">Choose gravel or road, from 3 to 5 days.</p>
-        <p class="fade-in delay-3"><strong>3T</strong> bikes available for rent.</p>
-      </div>
-    </section>
 
     <section class="fullpage-section" id="gallery">
       <div class="carousel">

--- a/fixed-styles.css
+++ b/fixed-styles.css
@@ -323,6 +323,22 @@ h3 {
   transition: opacity 1s ease;
 }
 
+.carousel-item::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 40%;
+  background: linear-gradient(to bottom, rgba(0,0,0,0.5), rgba(0,0,0,0));
+  z-index: 0;
+}
+
+.carousel-item > * {
+  position: relative;
+  z-index: 1;
+}
+
 .carousel-item.active {
   opacity: 1;
 }
@@ -405,6 +421,12 @@ h3 {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+#contact-form .content {
+  padding-top: 4rem;
+  padding-bottom: 2rem;
+  overflow-y: auto;
 }
 
 .form-group {
@@ -529,9 +551,10 @@ h3 {
   }
   
   .stats {
-    flex-direction: column;
+    flex-direction: row;
+    flex-wrap: wrap;
     gap: 1rem;
-    align-items: flex-start;
+    justify-content: center;
   }
   
   #tour-bergamo .content {

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
   <div class="fullpage-container">
     <section class="fullpage-section" id="hero">
       <div class="background">
-        <img src="images/home.jpg" alt="Giro Pizza Background" style="width:100%;height:100%;object-fit:cover;position:absolute;top:0;left:0;z-index:-2;">
+        <img src="images/home.png" alt="Giro Pizza Background" style="width:100%;height:100%;object-fit:cover;position:absolute;top:0;left:0;z-index:-2;">
         <div class="background-overlay"></div>
       </div>
       <div class="content">
@@ -73,13 +73,13 @@
     
     <section class="fullpage-section" id="tour-bergamo" style="display: flex; justify-content: center; align-items: center; height: 100vh;">
       <div class="background" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; z-index: -1;">
-        <img src="images/home.jpg" alt="Tour delle Colline Background" style="width: 100%; height: 100%; object-fit: cover; position: absolute; top: 0; left: 0; z-index: -2;">
+        <img src="images/home.png" alt="Tour delle Colline Background" style="width: 100%; height: 100%; object-fit: cover; position: absolute; top: 0; left: 0; z-index: -2;">
         <div class="background-overlay" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.35); z-index: -1;"></div>
       </div>
       <div class="content" style="text-align: center; z-index: 0;">
         <h2 class="fade-in">I NOSTRI TOUR</h2>
-        <div class="carousel tour-carousel" style="max-width: 80%; margin: auto;">
-          <div class="carousel-item active">
+        <div class="carousel tour-carousel">
+          <div class="carousel-item active" style="background-image: url('images/carousel/carousel_1.jpg')">
             <h3>Bormio e Stelvio</h3>
             <p class="carousel-description">Salite leggendarie e panorami epici.</p>
             <div class="stats">
@@ -89,7 +89,7 @@
               </div>
               <a href="bormio.html" class="minimal-button fade-in delay-2">DETTAGLI</a>
           </div>
-          <div class="carousel-item">
+          <div class="carousel-item" style="background-image: url('images/carousel/carousel_2.jpg')">
             <h3>Dolomiti</h3>
             <p class="carousel-description">I passi iconici delle Dolomiti.</p>
             <div class="stats">
@@ -98,6 +98,16 @@
                 <div class="stat"><span class="stat-number" data-value="4">0</span> h</div>
               </div>
               <a href="dolomiti.html" class="minimal-button">DETTAGLI</a>
+          </div>
+          <div class="carousel-item" style="background-image: url('images/home.png')">
+            <h3>Valpolicella</h3>
+            <p class="carousel-description">Vigneti, salite morbide e ottimi vini.</p>
+            <div class="stats">
+                <div class="stat"><span class="stat-number" data-value="70">0</span> km</div>
+                <div class="stat"><span class="stat-number" data-value="1000">0</span> m</div>
+                <div class="stat"><span class="stat-number" data-value="4">0</span> h</div>
+              </div>
+              <a href="valpolicella.html" class="minimal-button">DETTAGLI</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update hero images to `home.png`
- unify carousel styles and extend Italian carousel
- remove English "Featured Tours" section
- add gradient overlay on carousel items
- keep stats inline on small screens
- improve contact form spacing
- expand Dolomiti pages with 3 stages and new nav link to `TOUR`

## Testing
- `tidy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413c64ca948320b7d6abd5a0c86a14