### PR TITLE
Improve site language structure

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="main.css">
     
     <!-- Structured Data -->
     <script type="application/ld+json">

--- a/cookie.html
+++ b/cookie.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="main.css">
 </head>
 <body>
     <!-- Skip Link for Accessibility -->

--- a/destinazioni.html
+++ b/destinazioni.html
@@ -29,7 +29,7 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css">
     
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="main.css">
     
     <!-- Structured Data -->
     <script type="application/ld+json">

--- a/en/blog.html
+++ b/en/blog.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blog - Giro Pizza</title>
+  <link rel="stylesheet" href="../fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contact.html" class="nav-button">CONTACT</a>
+    <a href="about-us.html" class="nav-button">ABOUT</a>
+  </nav>
+  <div class="language-selector">
+    <a href="../blog.html" class="lang-button">IT</a>
+    <a href="blog.html" class="lang-button active">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" style="display:flex;justify-content:center;align-items:center">
+      <h1>Blog coming soon in English.</h1>
+    </section>
+  </div>
+</body>
+</html>

--- a/en/cookie.html
+++ b/en/cookie.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cookie Policy - Giro Pizza</title>
+  <link rel="stylesheet" href="../fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contact.html" class="nav-button">CONTACT</a>
+    <a href="about-us.html" class="nav-button">ABOUT</a>
+  </nav>
+  <div class="language-selector">
+    <a href="../cookie.html" class="lang-button">IT</a>
+    <a href="cookie.html" class="lang-button active">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" style="display:flex;justify-content:center;align-items:center">
+      <h1>Cookie policy coming soon in English.</h1>
+    </section>
+  </div>
+</body>
+</html>

--- a/en/custom-tour.html
+++ b/en/custom-tour.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Custom Tour - Giro Pizza</title>
+  <link rel="stylesheet" href="../fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contact.html" class="nav-button">CONTACT</a>
+    <a href="about-us.html" class="nav-button">ABOUT</a>
+  </nav>
+  <div class="language-selector">
+    <a href="../tour-personalizzato.html" class="lang-button">IT</a>
+    <a href="custom-tour.html" class="lang-button active">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" style="display:flex;justify-content:center;align-items:center">
+      <h1>Custom tour request coming soon in English.</h1>
+    </section>
+  </div>
+</body>
+</html>

--- a/en/destinations.html
+++ b/en/destinations.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Destinations - Giro Pizza</title>
+  <link rel="stylesheet" href="../fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contact.html" class="nav-button">CONTACT</a>
+    <a href="about-us.html" class="nav-button">ABOUT</a>
+  </nav>
+  <div class="language-selector">
+    <a href="../destinazioni.html" class="lang-button">IT</a>
+    <a href="destinations.html" class="lang-button active">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" style="display:flex;justify-content:center;align-items:center">
+      <h1>Destinations page coming soon in English.</h1>
+    </section>
+  </div>
+</body>
+</html>

--- a/en/faq.html
+++ b/en/faq.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>FAQ - Giro Pizza</title>
+  <link rel="stylesheet" href="../fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contact.html" class="nav-button">CONTACT</a>
+    <a href="about-us.html" class="nav-button">ABOUT</a>
+  </nav>
+  <div class="language-selector">
+    <a href="../faq.html" class="lang-button">IT</a>
+    <a href="faq.html" class="lang-button active">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" style="display:flex;justify-content:center;align-items:center">
+      <h1>FAQ coming soon in English.</h1>
+    </section>
+  </div>
+</body>
+</html>

--- a/en/flavors.html
+++ b/en/flavors.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flavors - Giro Pizza</title>
+  <link rel="stylesheet" href="../fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contact.html" class="nav-button">CONTACT</a>
+    <a href="about-us.html" class="nav-button">ABOUT</a>
+  </nav>
+  <div class="language-selector">
+    <a href="../sapori.html" class="lang-button">IT</a>
+    <a href="flavors.html" class="lang-button active">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" style="display:flex;justify-content:center;align-items:center">
+      <h1>Flavors of Northern Italy coming soon in English.</h1>
+    </section>
+  </div>
+</body>
+</html>

--- a/en/privacy.html
+++ b/en/privacy.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy - Giro Pizza</title>
+  <link rel="stylesheet" href="../fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contact.html" class="nav-button">CONTACT</a>
+    <a href="about-us.html" class="nav-button">ABOUT</a>
+  </nav>
+  <div class="language-selector">
+    <a href="../privacy.html" class="lang-button">IT</a>
+    <a href="privacy.html" class="lang-button active">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" style="display:flex;justify-content:center;align-items:center">
+      <h1>Privacy policy coming soon in English.</h1>
+    </section>
+  </div>
+</body>
+</html>

--- a/en/terms.html
+++ b/en/terms.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms - Giro Pizza</title>
+  <link rel="stylesheet" href="../fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contact.html" class="nav-button">CONTACT</a>
+    <a href="about-us.html" class="nav-button">ABOUT</a>
+  </nav>
+  <div class="language-selector">
+    <a href="../termini.html" class="lang-button">IT</a>
+    <a href="terms.html" class="lang-button active">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" style="display:flex;justify-content:center;align-items:center">
+      <h1>Terms and conditions coming soon in English.</h1>
+    </section>
+  </div>
+</body>
+</html>

--- a/en/tour.html
+++ b/en/tour.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tours - Giro Pizza</title>
+  <link rel="stylesheet" href="../fixed-styles.css">
+</head>
+<body>
+  <nav class="minimal-nav">
+    <a href="index.html" class="nav-button">HOME</a>
+    <a href="contact.html" class="nav-button">CONTACT</a>
+    <a href="about-us.html" class="nav-button">ABOUT</a>
+  </nav>
+  <div class="language-selector">
+    <a href="../tour.html" class="lang-button">IT</a>
+    <a href="tour.html" class="lang-button active">EN</a>
+  </div>
+  <div class="fullpage-container">
+    <section class="fullpage-section" style="display:flex;justify-content:center;align-items:center">
+      <h1>Tours listing coming soon in English.</h1>
+    </section>
+  </div>
+</body>
+</html>

--- a/faq.html
+++ b/faq.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="main.css">
     
     <!-- Structured Data -->
     <script type="application/ld+json">

--- a/privacy.html
+++ b/privacy.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="main.css">
 </head>
 <body>
     <!-- Skip Link for Accessibility -->

--- a/sapori.html
+++ b/sapori.html
@@ -29,7 +29,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@8/swiper-bundle.min.css">
     
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="main.css">
     
     <!-- Structured Data -->
     <script type="application/ld+json">

--- a/termini.html
+++ b/termini.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="main.css">
 </head>
 <body>
     <!-- Skip Link for Accessibility -->

--- a/tour-personalizzato.html
+++ b/tour-personalizzato.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="main.css">
     
     <!-- Structured Data -->
     <script type="application/ld+json">

--- a/tour.html
+++ b/tour.html
@@ -26,7 +26,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
     
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="css/main.css">
+    <link rel="stylesheet" href="main.css">
     
     <!-- Structured Data -->
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- fix incorrect CSS paths referencing css/main.css
- add placeholder English versions for pages that were only in Italian

## Testing
- `npx -y htmlhint '**/*.html'`

------
https://chatgpt.com/codex/tasks/task_e_68419f3d35a48320ae7df38c0bfa5ef8